### PR TITLE
Improve rating and playback validation to prevent duplicates / skipped stimuli and support test resumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ just remove `"gray_video": "..."` in your config file.
 Just run `avrateNG.py -h` and you will get the following screen:
 
 ```
-usage: avrateNG.py [-h] [-configfilename CONFIGFILENAME] [--standalone]
-                   [--development]
+usage: avrateNG.py [-h] [-configfilename CONFIGFILENAME] [--standalone] 
+                   [--development] [--user_id USER_ID]
 
 AVRateNG
 
@@ -133,9 +133,13 @@ options:
                         configuration file name (default: config.json)
   --standalone          run as standalone version (default: False)
   --development, -d     run in dev mode (default: False)
+  --user_id USER_ID     Manually set user ID for ratings (default: None)
 
 stg7 2023
 ```
+
+`user_id` can be set to continue a test run (eg. after accidentally closing the browser) and the test will continue from the last rated sequence.
+
 
 ### Templates
 

--- a/avrateNG.py
+++ b/avrateNG.py
@@ -66,7 +66,7 @@ def play(db, config, stimuli_idx):
     play a given media file by its index inside the playlist
     """
     stimuli_idx = int(stimuli_idx)
-    lInfo(f"play {stimuli_idx}")
+    lInfo(f"Play Stimuli {stimuli_idx}")
 
 
     user_id, playlist_idx = get_user_id_playlist(db, config)
@@ -98,13 +98,11 @@ def play(db, config, stimuli_idx):
 
     stimuli_file = " ".join(map(q, stimuli_file))
 
-    lInfo("play {}".format(stimuli_file))
+    lInfo(f"Play Stimuli: {stimuli_file}")
     if "gray_video" in config:
         stimuli_file = q(config["gray_video"]) + " " + stimuli_file + " " + q(config["gray_video"])
-        lInfo("use gray video before and after: {}".format(stimuli_file))
-    lInfo("player command")
-
-    lInfo(config["player"].format(filename=stimuli_file))
+        lInfo(f"Use gray video before and after: {stimuli_file}")
+    lInfo(f"Player Command: {config['player'].format(filename=stimuli_file)}")
     shell_call(config["player"].format(filename=stimuli_file))
 
 
@@ -148,14 +146,14 @@ def rating_already_exists(db, user_id, stimuli_idx):
     return count > 0
 
 
-def check_all_ratings_complete(db, user_id, current_stimuli_idx, playlist):
+def check_all_ratings_complete(db, user_id, current_stimuli_idx, playlist, playlist_idx):
     """
     checks if all previous were rated correctly
     """
     expected_files = set()
     for i in range(current_stimuli_idx+1):
-        if i < len(playlist):
-            expected_files.add(playlist[i])
+        if i < len(playlist_idx):
+            expected_files.add(str(playlist[playlist_idx[i]]))
     
     cursor = db.execute(
         'SELECT DISTINCT stimuli_file FROM ratings WHERE user_ID = ?',
@@ -174,7 +172,6 @@ def check_all_ratings_complete(db, user_id, current_stimuli_idx, playlist):
               f"Rated Files:\t{rated_files}")
     
     return all_ratings_complete
-
 
 
 @route('/')  # Welcome screen
@@ -205,8 +202,11 @@ def welcome(db, config):
 
 @route('/start_test')
 def start_test(config, db):
+    lInfo("\nSTARTING TEST")
     response.set_cookie("training", "0", path="/")
     response.set_cookie("training_state", "done", path="/")
+    response.set_cookie("stimuli_done", "0", path="/")
+    response.set_cookie("videos_shown", "[]", path="/") 
     return template(
         config["template_folder"] + "/start_test.tpl",
         title="AVRateNG"
@@ -216,7 +216,6 @@ def start_test(config, db):
 @route('/training/<stimuli_idx>')
 @route('/training/<stimuli_idx>', method="POST")
 def training(config, db, stimuli_idx):
-
     user_id = int(request.get_cookie("user_id"))
     stimuli_idx = int(stimuli_idx)
 
@@ -252,9 +251,17 @@ def rate(db, config, stimuli_idx):
     stimuli_done = int(request.get_cookie("stimuli_done"))
     
     if not stimuli_idx == stimuli_done or rating_already_exists(db, user_id, stimuli_idx):
-        stimuli_done = int(request.get_cookie("stimuli_done"))
-        if stimuli_done == stimuli_idx:
-            stimuli_done += 1
+        # find first rating that does not exist yet
+        next_stimuli = 0 
+        while next_stimuli < len(config["playlist"]) and rating_already_exists(db, user_id, next_stimuli):
+            next_stimuli += 1
+        
+        if next_stimuli >= len(config["playlist"]):
+            redirect('/finish')
+            return
+            
+        stimuli_done = next_stimuli
+        response.set_cookie("stimuli_done", str(stimuli_done), path="/")
         lWarn(f"Requested stimuli index {stimuli_idx} is unexpected or exists already, using stimuli_done {stimuli_done} instead.")
         redirect('/rate/' + str(stimuli_done))
 
@@ -355,7 +362,8 @@ def save_rating(db, config):
     stimuli_done = int(request.get_cookie("stimuli_done"))
     lInfo(f"Saved Rating (UID: {user_id} SID: {stimuli_ID} TS: {timestamp} Stimuli File: {stimuli_file} Stimuli Done (Prev): {stimuli_done}")
 
-    if check_all_ratings_complete(db, user_id, stimuli_done, [str(p) for p in config["playlist"]]):
+    user_id, playlist_idx = get_user_id_playlist(db, config)
+    if check_all_ratings_complete(db, user_id, stimuli_done, config["playlist"], playlist_idx):
         stimuli_done += 1
     else:
         lWarn(f"Not all previous ratings complete for user {user_id}, stimuli {stimuli_idx} (REPEATING STIMULI)")
@@ -445,14 +453,14 @@ def get_and_check_playlist(playlistfilename):
             normalized_video_path = os.path.join(*line.strip().split("/"))
             # check if each video exists
             if " | " in normalized_video_path:
-                lInfo("specified multiple videos per playlist entry")
+                lInfo("Specified multiple videos per playlist entry")
             videos = normalized_video_path.split(" | ")
             for video in videos:
                 if not os.path.isfile(video):
                     lError("'{}' is not a valid videofile, please check your playlistfile".format(normalized_video_path))
                     sys.exit(-1)
             playlist.append(videos)
-        lInfo("\n".join(map(str, playlist)))
+        lInfo(f"{os.path.basename(playlistfilename)}:\n" + '\n'.join(map(str, playlist)))
         return playlist
     return -1
 

--- a/avrateNG.py
+++ b/avrateNG.py
@@ -70,7 +70,7 @@ def play(db, config, stimuli_idx):
 
 
     user_id, playlist_idx = get_user_id_playlist(db, config)
-    training = int(request.get_cookie("training", "0"))
+    training = not request.get_cookie("training_state") == "done"
     if training:
         stimuli_file = config["trainingsplaylist"][stimuli_idx]
     else:
@@ -106,13 +106,22 @@ def play(db, config, stimuli_idx):
     shell_call(config["player"].format(filename=stimuli_file))
 
 
-
 def get_user_id_playlist(db, config):
     if request.get_cookie("user_id"):
         user_id = int(request.get_cookie("user_id"))
         playlist = json.loads(db.execute('SELECT playlist from user_playlist where user_ID==? ;', (user_id,)).fetchone()[0])
         return user_id, playlist
     """ read user id from database """
+    if config.get("manual_user_id") is not None:
+        user_id = int(config["manual_user_id"])
+        response.set_cookie("user_id", str(user_id), path="/")
+        try:
+            playlist = json.loads(db.execute('SELECT playlist from user_playlist where user_ID==? ;', (user_id,)).fetchone()[0])
+            return user_id, playlist
+        except Exception as e:
+            lError(f"Error loading playlist for user ID {user_id}: {e}")
+            exit(1)
+
     if not db.execute("SELECT * FROM sqlite_master WHERE type='table' AND name='ratings'").fetchone():
         user_id = 1 # if ratings table does not exist: first user_id = 1
     else:
@@ -173,6 +182,16 @@ def check_all_ratings_complete(db, user_id, current_stimuli_idx, playlist, playl
     
     return all_ratings_complete
 
+def user_has_existing_ratings(db, user_id):
+    """
+    checks if the user has existing ratings in the database (excluding user_registered entries)
+    """
+    cursor = db.execute(
+        'SELECT COUNT(*) FROM ratings WHERE user_ID = ? AND rating_type != ?',
+        (user_id, "user_registered")
+    )
+    count = cursor.fetchone()[0]
+    return count > 0
 
 @route('/')  # Welcome screen
 @auth_basic(check_credentials)
@@ -192,6 +211,8 @@ def welcome(db, config):
         if not request.get_cookie("training_state") == "done": # Cookie that controls if training was already done or is still open
             response.set_cookie("training_state","open", path="/")
             response.set_cookie("training", "1", path="/")
+    else:
+        response.set_cookie("training_state","done", path="/")
 
     return template(
         config["template_folder"] + "/welcome.tpl",
@@ -265,8 +286,7 @@ def rate(db, config, stimuli_idx):
         lWarn(f"Requested stimuli index {stimuli_idx} is unexpected or exists already, using stimuli_done {stimuli_done} instead.")
         redirect('/rate/' + str(stimuli_done))
 
-    training = int(request.get_cookie("training", "0"))
-
+    training = not request.get_cookie("training_state") == "done"
     # Select correct playlist for lookup
     playlist = "playlist"
     if training:
@@ -288,10 +308,15 @@ def rate(db, config, stimuli_idx):
 
 @route('/questionnaire')
 @auth_basic(check_credentials)
-def questionnaire(config):
+def questionnaire(db, config):
     """
     show questionnaire if required
     """
+    if user_has_existing_ratings(db, int(request.get_cookie("user_id"))):
+        lWarn("User already has ratings, skipping questionnaire and training")
+        response.set_cookie("training_state", "done", path="/")
+        return redirect('/rate/0')
+
     if not config.get("questionnaire", True):
         if int(request.get_cookie("training")) > 0:
             redirect('/training/0')
@@ -474,17 +499,18 @@ def main(params=[]):
     parser.add_argument('-configfilename', type=str, default="config.json", help='configuration file name')
     parser.add_argument('--standalone', action='store_true', help="run as standalone version")
     parser.add_argument('--development', '-d', action='store_true', help="run in dev mode")
+    parser.add_argument('--user_id', type=str, default=None, help="Manually set user ID for ratings")
 
     argsdict = vars(parser.parse_args())
-    lInfo("read config {}".format(argsdict["configfilename"]))
+    lInfo("Read config {}".format(argsdict["configfilename"]))
     # read config file
     try:
         config = json.loads(read_file(os.path.dirname(os.path.realpath(__file__)) + "/" + argsdict["configfilename"]))
     except Exception as e:
-        lError("configuration file 'config.json' is corrupt (not json conform). Error: " + str(e))
+        lError("Configuration file 'config.json' is corrupt (not json conform). Error: " + str(e))
         return 1
     config["development"] = argsdict["development"]
-    lInfo("read playlist {}".format(config["playlist"]))
+    lInfo("Read playlist {}".format(config["playlist"]))
 
     config["playlist"] = get_and_check_playlist(config["playlist"])
 
@@ -504,6 +530,10 @@ def main(params=[]):
         # open (default) web browser
         webbrowser.open("http://127.0.0.1:{port}/".format(port=config["http_port"]), new=1, autoraise=True)
         return
+
+    if argsdict["user_id"] is not None:
+        config["manual_user_id"] = argsdict["user_id"]
+        lInfo(f"Manually set user ID: {argsdict['user_id']}")
 
     # default case: run in server mode
     server(config, host='0.0.0.0')

--- a/avrateNG.py
+++ b/avrateNG.py
@@ -66,22 +66,36 @@ def play(db, config, stimuli_idx):
     play a given media file by its index inside the playlist
     """
     stimuli_idx = int(stimuli_idx)
-    print("play", stimuli_idx)
+    lInfo(f"play {stimuli_idx}")
+
 
     user_id, playlist_idx = get_user_id_playlist(db, config)
-    if int(request.get_cookie("training")):
+    training = int(request.get_cookie("training", "0"))
+    if training:
         stimuli_file = config["trainingsplaylist"][stimuli_idx]
     else:
         stimuli_file = config["playlist"][playlist_idx[stimuli_idx]]
 
-    print(stimuli_file)
     if config.get("no_media_playback", False):
+        return
+
+    videos_shown = json.loads(request.get_cookie("videos_shown", "[]"))
+
+    # used to avoid false positives from training/playback or duplicate videos in the playlist
+    video_identifier = f"U{user_id}_S{stimuli_idx}_{'train' if training else 'test'}" 
+    lInfo(f"Videos already shown: {videos_shown}")
+    if video_identifier in videos_shown:
+        lWarn(f"Video {stimuli_file} already shown, skipping playback.")
         return
 
     def q(x):
         """ quote the media name for command line usage,
         prevends problems with spaces in media filenames"""
         return "\"" + x + "\""
+
+    videos_shown.append(video_identifier)
+    response.set_cookie("videos_shown", json.dumps(videos_shown), path="/")
+
     stimuli_file = " ".join(map(q, stimuli_file))
 
     lInfo("play {}".format(stimuli_file))
@@ -89,7 +103,8 @@ def play(db, config, stimuli_idx):
         stimuli_file = q(config["gray_video"]) + " " + stimuli_file + " " + q(config["gray_video"])
         lInfo("use gray video before and after: {}".format(stimuli_file))
     lInfo("player command")
-    print(config["player"].format(filename=stimuli_file))
+
+    lInfo(config["player"].format(filename=stimuli_file))
     shell_call(config["player"].format(filename=stimuli_file))
 
 
@@ -121,6 +136,47 @@ def get_user_id_playlist(db, config):
     return user_id, playlist
 
 
+def rating_already_exists(db, user_id, stimuli_idx):
+    """
+    checks if a rating for the given user_id and stimuli_idx already exists
+    """
+    cursor = db.execute(
+        'SELECT COUNT(*) FROM ratings WHERE user_ID = ? AND stimuli_ID = ?',
+        (user_id, stimuli_idx)
+    )
+    count = cursor.fetchone()[0]
+    return count > 0
+
+
+def check_all_ratings_complete(db, user_id, current_stimuli_idx, playlist):
+    """
+    checks if all previous were rated correctly
+    """
+    expected_files = set()
+    for i in range(current_stimuli_idx+1):
+        if i < len(playlist):
+            expected_files.add(playlist[i])
+    
+    cursor = db.execute(
+        'SELECT DISTINCT stimuli_file FROM ratings WHERE user_ID = ?',
+        (user_id,)
+    )
+    rated_files = set(row[0] for row in cursor.fetchall())
+    all_ratings_complete = expected_files.issubset(rated_files)
+
+    if all_ratings_complete:
+        lInfo(f"All ratings complete for user {user_id} up to stimuli index {current_stimuli_idx}\n" +
+              f"Expected Files:\t{expected_files}\n" +
+              f"Rated Files:\t{rated_files}")
+    else:
+        lWarn(f"Not all ratings complete for user {user_id} up to stimuli index {current_stimuli_idx}\n" +
+              f"Expected Files:\t{expected_files}\n" +
+              f"Rated Files:\t{rated_files}")
+    
+    return all_ratings_complete
+
+
+
 @route('/')  # Welcome screen
 @auth_basic(check_credentials)
 def welcome(db, config):
@@ -130,11 +186,9 @@ def welcome(db, config):
     user_id, playlist = get_user_id_playlist(db, config)
 
     response.set_cookie("user_id", str(user_id), path="/")
-
-    # initialize session_state variable (throws error when refreshing the page or going back)
-    response.set_cookie("session_state", "0", path="/")
     response.set_cookie("stimuli_done", "0", path="/")
     response.set_cookie("training", "0", path="/")
+    response.set_cookie("videos_shown", "[]", path="/") # used to avoid showing the same video multiple times
 
     # check if training stage is wished and/or training has already finished:
     if config["trainingsplaylist"]: # check if training switch is toggled
@@ -194,31 +248,22 @@ def rate(db, config, stimuli_idx):
     show rating screen for one specific stimuli
     """
     stimuli_idx = int(stimuli_idx)
-
     user_id, playlist_idx = get_user_id_playlist(db, config)
-
-    session_state = int(request.get_cookie("session_state"))
     stimuli_done = int(request.get_cookie("stimuli_done"))
+    
+    if not stimuli_idx == stimuli_done or rating_already_exists(db, user_id, stimuli_idx):
+        stimuli_done = int(request.get_cookie("stimuli_done"))
+        if stimuli_done == stimuli_idx:
+            stimuli_done += 1
+        lWarn(f"Requested stimuli index {stimuli_idx} is unexpected or exists already, using stimuli_done {stimuli_done} instead.")
+        redirect('/rate/' + str(stimuli_done))
+
+    training = int(request.get_cookie("training", "0"))
 
     # Select correct playlist for lookup
-    if int(request.get_cookie("training")):
+    playlist = "playlist"
+    if training:
         playlist = "trainingsplaylist"
-    else:
-        playlist = "playlist"
-
-    # Check if video should be played or was already watched
-    if stimuli_idx == session_state:
-        play_video = 1
-    else:
-        play_video = 0
-
-    # play video only on first visit
-    if play_video == 1:
-        # play(config, stimuli_idx, playlist)  # the play call (via the play route) is moved to the rating template
-        # play just one time
-        play_video = 0
-        session_state = session_state + 1
-        response.set_cookie("session_state", str(session_state), path="/")
 
     return template(
         config["template_folder"] + "/rate.tpl",
@@ -289,8 +334,6 @@ def save_rating(db, config):
     timestamp = create_timestamp()
 
     user_id = int(request.get_cookie("user_id"))
-    stimuli_done = int(request.get_cookie("stimuli_done")) + 1
-    response.set_cookie("stimuli_done", str(stimuli_done), path="/")
 
     # get POST data ratings and write to DB
     request_data_pairs = {}
@@ -302,20 +345,28 @@ def save_rating(db, config):
     excluded = ["stimuli_idx", "stimuli_file"]
 
     db.execute('CREATE TABLE IF NOT EXISTS ratings (user_ID INTEGER, stimuli_ID TEXT, stimuli_file TEXT, rating_type TEXT, rating TEXT, timestamp TEXT);')
-
     for item in filter(lambda x: x not in excluded , request_data_pairs):
         db.execute(
             'INSERT INTO ratings VALUES (?,?,?,?,?,?);',
             (user_id, stimuli_ID, stimuli_file, item, request_data_pairs[item], timestamp)
         )
-
     db.commit()
+
+    stimuli_done = int(request.get_cookie("stimuli_done"))
+    lInfo(f"Saved Rating (UID: {user_id} SID: {stimuli_ID} TS: {timestamp} Stimuli File: {stimuli_file} Stimuli Done (Prev): {stimuli_done}")
+
+    if check_all_ratings_complete(db, user_id, stimuli_done, [str(p) for p in config["playlist"]]):
+        stimuli_done += 1
+    else:
+        lWarn(f"Not all previous ratings complete for user {user_id}, stimuli {stimuli_idx} (REPEATING STIMULI)")
+
+    response.set_cookie("stimuli_done", str(stimuli_done), path="/")
+    lInfo(f"Updated STIMULI DONE: {stimuli_done}") 
 
     if stimuli_done >= len(config["playlist"]):
         redirect('/finish')
 
     redirect('/rate/' + str(stimuli_done))
-
 
 
 @route('/static/<filename:path>',name='static')  # access the stylesheets and static files (JS files,...)
@@ -367,6 +418,7 @@ def reset_cookies(db, config):
         response.set_cookie(cookie, '', expires=0)
     redirect('/')
 
+
 @route('/dev')
 def dev(db, config):
     """
@@ -400,7 +452,7 @@ def get_and_check_playlist(playlistfilename):
                     lError("'{}' is not a valid videofile, please check your playlistfile".format(normalized_video_path))
                     sys.exit(-1)
             playlist.append(videos)
-        print("\n".join(map(str, playlist)))
+        lInfo("\n".join(map(str, playlist)))
         return playlist
     return -1
 

--- a/avrateNG.py
+++ b/avrateNG.py
@@ -66,15 +66,14 @@ def play(db, config, stimuli_idx):
     play a given media file by its index inside the playlist
     """
     stimuli_idx = int(stimuli_idx)
-    lInfo(f"Play Stimuli {stimuli_idx}")
-
-
     user_id, playlist_idx = get_user_id_playlist(db, config)
     training = not request.get_cookie("training_state") == "done"
     if training:
         stimuli_file = config["trainingsplaylist"][stimuli_idx]
     else:
         stimuli_file = config["playlist"][playlist_idx[stimuli_idx]]
+
+    lInfo(f"Play Stimuli {stimuli_idx} ({'train' if training else 'test'}) for user {user_id}: {stimuli_file}")
 
     if config.get("no_media_playback", False):
         return
@@ -83,9 +82,8 @@ def play(db, config, stimuli_idx):
 
     # used to avoid false positives from training/playback or duplicate videos in the playlist
     video_identifier = f"U{user_id}_S{stimuli_idx}_{'train' if training else 'test'}" 
-    lInfo(f"Videos already shown: {videos_shown}")
     if video_identifier in videos_shown:
-        lWarn(f"Video {stimuli_file} already shown, skipping playback.")
+        lWarn(f"Video {stimuli_file} ({video_identifier}) already shown, skipping playback.")
         return
 
     def q(x):
@@ -98,7 +96,6 @@ def play(db, config, stimuli_idx):
 
     stimuli_file = " ".join(map(q, stimuli_file))
 
-    lInfo(f"Play Stimuli: {stimuli_file}")
     if "gray_video" in config:
         stimuli_file = q(config["gray_video"]) + " " + stimuli_file + " " + q(config["gray_video"])
         lInfo(f"Use gray video before and after: {stimuli_file}")
@@ -172,9 +169,7 @@ def check_all_ratings_complete(db, user_id, current_stimuli_idx, playlist, playl
     all_ratings_complete = expected_files.issubset(rated_files)
 
     if all_ratings_complete:
-        lInfo(f"All ratings complete for user {user_id} up to stimuli index {current_stimuli_idx}\n" +
-              f"Expected Files:\t{expected_files}\n" +
-              f"Rated Files:\t{rated_files}")
+        lInfo(f"All ratings complete for user {user_id} up to stimuli index {current_stimuli_idx}")
     else:
         lWarn(f"Not all ratings complete for user {user_id} up to stimuli index {current_stimuli_idx}\n" +
               f"Expected Files:\t{expected_files}\n" +
@@ -378,14 +373,23 @@ def save_rating(db, config):
 
     db.execute('CREATE TABLE IF NOT EXISTS ratings (user_ID INTEGER, stimuli_ID TEXT, stimuli_file TEXT, rating_type TEXT, rating TEXT, timestamp TEXT);')
     for item in filter(lambda x: x not in excluded , request_data_pairs):
-        db.execute(
-            'INSERT INTO ratings VALUES (?,?,?,?,?,?);',
-            (user_id, stimuli_ID, stimuli_file, item, request_data_pairs[item], timestamp)
-        )
+        # Check for duplicates
+        existing = db.execute('SELECT 1 FROM ratings WHERE user_ID=? AND stimuli_ID=? AND stimuli_file=? AND rating_type=?',
+                              (user_id, stimuli_ID, stimuli_file, item)).fetchone()
+
+        if existing:
+            lError(f"Duplicate rating detected for user {user_id}, stimuli {stimuli_ID}, file {stimuli_file}, type {item}. Skipping insertion.")
+            lError(f"Existing entry: {existing}")
+            lError(f"New entry:      {(user_id, stimuli_ID, stimuli_file, item, request_data_pairs[item], timestamp)}")
+        else:
+            db.execute(
+                'INSERT INTO ratings VALUES (?,?,?,?,?,?);',
+                (user_id, stimuli_ID, stimuli_file, item, request_data_pairs[item], timestamp)
+            )
     db.commit()
 
     stimuli_done = int(request.get_cookie("stimuli_done"))
-    lInfo(f"Saved Rating (UID: {user_id} SID: {stimuli_ID} TS: {timestamp} Stimuli File: {stimuli_file} Stimuli Done (Prev): {stimuli_done}")
+    lInfo(f"Saved Rating (UID: {user_id} / SID: {stimuli_ID} / Stimuli Done (Prev): {stimuli_done} / Data: {request_data_pairs})")
 
     user_id, playlist_idx = get_user_id_playlist(db, config)
     if check_all_ratings_complete(db, user_id, stimuli_done, config["playlist"], playlist_idx):
@@ -394,7 +398,6 @@ def save_rating(db, config):
         lWarn(f"Not all previous ratings complete for user {user_id}, stimuli {stimuli_idx} (REPEATING STIMULI)")
 
     response.set_cookie("stimuli_done", str(stimuli_done), path="/")
-    lInfo(f"Updated STIMULI DONE: {stimuli_done}") 
 
     if stimuli_done >= len(config["playlist"]):
         redirect('/finish')


### PR DESCRIPTION
Hey all, 

I had issues during previous tests where some ratings were written to the database multiple times (same id/rating), which would then skip the next ratings. This lead to some users not seeing all the stimuli (and duplicate ratings for other stimuli).

This PR mainly tries to address this issue.

Instead of only relying on an ID saved in the cookies, this now both saves the played stimuli in cookies (to avoid playing a stimuli twice) and checks the actual database before writing and continuing to the next ID. This has the advantage that refreshing or manually editing the URL does not replay a video and instead goes to the newest not-yet-rated video (and only replays it if it has not been shown). This new approach also allows to continue a test if it is interrupted (eg. the browser is closed) with a new argument `--user_id`. This first checks the database if there is a user with ratings already and if so skips the intro / stimuli that have been rated before. Besides that I updated the logging to make it easier to spot such issues.

In a study on 32 people last month this worked well and 11 duplicates (from 5 users) were detected and avoided. Still I would recommend testing this before using it on an important test.

Cheers
